### PR TITLE
feature: add support for cross repo navigation

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,3 @@
 version = "3.5.8"
 project.git = true
 runner.dialect = scala213
-docstrings.wrap = no

--- a/itest/src/minimal/build.sc
+++ b/itest/src/minimal/build.sc
@@ -18,8 +18,17 @@ object minimalThree extends ScalaModule {
 def generate(ev: Evaluator) = T.command {
   val scipFile = Scip.generate(ev)()
 
-  val semanticdbFiles = os.walk(os.pwd / "out").filter(_.ext == "semanticdb")
+  val classpathFile = (scipFile / os.up / "javacopts.txt")
 
+  // We make sure that the javacopts.txt file was also created
+  assertEquals(os.exists(classpathFile), true)
+
+  val firstLine = os.read(classpathFile).takeWhile(_ != '\n')
+
+  // Ensure that the contents of this file were actually created correctly starting with the first line being -classpath
+  assertEquals(firstLine, "-classpath")
+
+  val semanticdbFiles = os.walk(os.pwd / "out").filter(_.ext == "semanticdb")
   // We should find 3 different semanticdb files to show that it's working in a
   // normal Scala 2 module, the test module, and the Scala 3 module.
   assertEquals(semanticdbFiles.size, 3)

--- a/plugin/src/io/kipp/mill/scip/ClasspathEntry.scala
+++ b/plugin/src/io/kipp/mill/scip/ClasspathEntry.scala
@@ -1,0 +1,45 @@
+package io.kipp.mill.scip
+
+import com.sourcegraph.scip_java.buildtools
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/** Helpers to calculate the classpath entries needed.
+  */
+object ClasspathEntry {
+
+  /** Tries to parse a ClasspathEntry from the POM file that lies next to the
+    * given jar file.
+    *
+    * Taken from:
+    * https://github.com/sourcegraph/scip-java/blob/9648fa9b2f0fc676aafa54c84342375666ce682b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/ClasspathEntry.scala#L102-L131
+    */
+  private[scip] def fromPom(jar: Path): Option[buildtools.ClasspathEntry] = {
+    val pom = jar
+      .resolveSibling(jar.getFileName.toString.stripSuffix(".jar") + ".pom")
+    val sources = Option(
+      jar.resolveSibling(
+        jar.getFileName.toString.stripSuffix(".jar") + ".sources"
+      )
+    ).filter(Files.isRegularFile(_))
+    if (Files.isRegularFile(pom)) {
+      val xml = scala.xml.XML.loadFile(pom.toFile)
+      def xmlValue(key: String): String = {
+        val node = xml \ key
+        if (node.isEmpty)
+          (xml \ "parent" \ key).text
+        else
+          node.text
+      }.trim
+      val groupId = xmlValue("groupId")
+      val artifactId = xmlValue("artifactId")
+      val version = xmlValue("version")
+      Some(
+        buildtools.ClasspathEntry(jar, sources, groupId, artifactId, version)
+      )
+    } else {
+      None
+    }
+  }
+}


### PR DESCRIPTION
This change captures "packages" that are then passed into the
`ScipSemanticdbOptions` so that the `index.scip` file as the information
it needs about the dependencies that are being used in the project. We
do persist this file next to the scip file, not next to the semanticdb
like is usually done. The main reason for this right now is that we're
the one putting together the actually scip, so I don't _believe_
anything will actually be using this file.
