### PR TITLE
fix: make sure to use scip-java name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ so you don't need to add anything to your build to use it. The easiest way to
 run this against your project is by the below command:
 
 ```
-mill --import ivy:io.chris-kipp::mill-scip::0.1.1 io.kipp.mill.scip.Scip/generate
+mill --import ivy:io.chris-kipp::mill-scip::0.2.0 io.kipp.mill.scip.Scip/generate
 ```
 
 This command will generate an `index.scip` file for you located in your

--- a/build.sc
+++ b/build.sc
@@ -58,8 +58,7 @@ object plugin
 
   override def buildInfoMembers = Map(
     "semanticDBVersion" -> semanticdb,
-    "semanticDBJavaVersion" -> semanticdbJava,
-    "version" -> publishVersion()
+    "semanticDBJavaVersion" -> semanticdbJava
   )
 
   override def buildInfoObjectName = "ScipBuildInfo"

--- a/plugin/src/io/kipp/mill/scip/Scip.scala
+++ b/plugin/src/io/kipp/mill/scip/Scip.scala
@@ -233,8 +233,10 @@ object Scip extends ExternalModule {
     val toolInfo =
       LsifToolInfo
         .newBuilder()
-        .setName("mill-scip")
-        .setVersion(ScipBuildInfo.version)
+        .setName(
+          "scip-java"
+        ) // Make sure this stays a recognized name by src or it won't index deps. Don't use mill-scip.
+        .setVersion(ScipBuildInfo.semanticDBJavaVersion)
         .build()
 
     log.info(s"Creating a index.scip in ${scipFile}")
@@ -251,6 +253,7 @@ object Scip extends ExternalModule {
       Seq("-classpath\n", projects.mkString(":")),
       createFolders = true
     )
+
     val classPathEntries =
       projects.flatMap(project => ClasspathEntry.fromPom(project.toNIO))
 


### PR DESCRIPTION
Using a custom name like `mill-scip` actually breaks the expectations
found in https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/cmd/worker/internal/codeintel/indexing/dependency_sync_scheduler.go?L235%3A1-252%3A2= and it causes deps not to be indexed. This switches it to `scip-java`.
