### PR TITLE
dep: bump mill-vcs-version to 0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out/
 .metals/
 .bsp/
 .bloop/
+index.scip

--- a/build.sc
+++ b/build.sc
@@ -1,7 +1,7 @@
 import $ivy.`com.goyeau::mill-scalafix::0.2.10`
 import $ivy.`com.lihaoyi::mill-contrib-buildinfo:$MILL_VERSION`
 import $ivy.`de.tototec::de.tobiasroeser.mill.integrationtest::0.6.1`
-import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.1.4`
+import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.2.0`
 
 import mill._
 import scalalib._
@@ -68,13 +68,7 @@ object plugin
     "io.kipp.mill.scip"
   )
 
-  override def publishVersion = VcsVersion
-    .vcsState()
-    .format(tagModifier = {
-      case t if t.startsWith("v") && Try(t.substring(1, 2).toInt).isSuccess =>
-        t.substring(1)
-      case t => t
-    })
+  override def publishVersion = VcsVersion.vcsState().format()
 
   override def pomSettings = PomSettings(
     description = "Generate SCIP for your Mill build.",


### PR DESCRIPTION
With this change I can also get rid of the extra logic
that I had to strip off the leading v since this is now
in mill-vcs-version
