### PR TITLE
feat: add in ability to specify the output type

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -93,7 +93,13 @@ object itest extends MillIntegrationTestModule {
     T {
       Seq(
         PathRef(testBase / "minimal") -> Seq(
-          TestInvocation.Targets(Seq("generate"), noServer = true)
+          TestInvocation.Targets(Seq("generate"), noServer = true),
+          TestInvocation.Targets(Seq("lsif"), noServer = true),
+          TestInvocation.Targets(
+            Seq("fail"),
+            noServer = true,
+            expectedExitCode = 1
+          )
         )
       )
     }

--- a/itest/src/minimal/build.sc
+++ b/itest/src/minimal/build.sc
@@ -35,3 +35,12 @@ def generate(ev: Evaluator) = T.command {
   // Then we ensure that the index.scip file was actually created
   assertEquals(os.exists(scipFile), true)
 }
+
+def lsif(ev: Evaluator) = T.command {
+  val scipFile = Scip.generate(ev, "dump.lsif")()
+  assertEquals(os.exists(scipFile), true)
+}
+
+def fail(ev: Evaluator) = T.command {
+  Scip.generate(ev, "wrong.format")
+}


### PR DESCRIPTION
This allows the user to pass in `--output dump.lsif` or just `dump.lsif`
or another valid output type to output other types than the default scip
which was happening before. If used the same way as before with no
argument the behavior is the same.

Refs: https://github.com/sourcegraph/scip-java/issues/482
