### PR TITLE
feat: add support for pure javaModules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
     - name: Check formatting
       run: 
         ./mill -i __.checkFormat
+
     - name: Check scalafix
       run: 
         ./mill -i __.fix --check
@@ -54,13 +55,13 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
 
-    - name: Compile
+    - name: Unit tests
       run:
-        ./mill -i __.compile
+        ./mill -i plugin.test
 
-    - name: Test
+    - name: Integration tests
       run:
-        ./mill -i --debug itest
+        ./mill -i --debug itest[_].test
 
   publish-sonatype:
     if: github.repository == 'ckipp01/mill-scip' && contains(github.ref, 'refs/tags/')

--- a/build.sc
+++ b/build.sc
@@ -24,6 +24,11 @@ val scala213 = "2.13.8"
 val semanticdb = "4.5.13"
 val semanticdbJava = "0.8.6"
 
+// We temporarily test against 0.10.7 as well before we have a 0.11.x just
+// to ensure that on that version we can also get semanticDB produced for
+// Java Modules.
+val millTestVersions = Seq(millVersion, "0.10.7")
+
 def millBinaryVersion(millVersion: String) = scalaNativeBinaryVersion(
   millVersion
 )
@@ -79,13 +84,20 @@ object plugin
     developers =
       Seq(Developer("ckipp01", "Chris Kipp", "https://www.chris-kipp.io"))
   )
+
+  object test extends Tests with TestModule.Munit {
+    def ivyDeps = Agg(ivy"org.scalameta::munit:1.0.0-M6")
+  }
 }
 
-object itest extends MillIntegrationTestModule {
+object itest extends Cross[ItestCross](millTestVersions: _*)
+class ItestCross(testVersion: String) extends MillIntegrationTestModule {
 
-  def millTestVersion = millVersion
+  def millTestVersion = testVersion
 
   def pluginsUnderTest = Seq(plugin)
+
+  override def millSourcePath = super.millSourcePath / os.up
 
   def testBase = millSourcePath / "src"
 

--- a/itest/src/minimal/build.sc
+++ b/itest/src/minimal/build.sc
@@ -15,6 +15,8 @@ object minimalThree extends ScalaModule {
   def scalaVersion = "3.1.3"
 }
 
+object minimalJava extends JavaModule
+
 def generate(ev: Evaluator) = T.command {
   val scipFile = Scip.generate(ev)()
 
@@ -29,9 +31,12 @@ def generate(ev: Evaluator) = T.command {
   assertEquals(firstLine, "-classpath")
 
   val semanticdbFiles = os.walk(os.pwd / "out").filter(_.ext == "semanticdb")
-  // We should find 3 different semanticdb files to show that it's working in a
-  // normal Scala 2 module, the test module, and the Scala 3 module.
-  assertEquals(semanticdbFiles.size, 3)
+  // A little hacky but we want to check if the user is on 0.10.7 or not because
+  // that's when Java support was added, so if we are on that version we expect
+  // 4 semanticDB documents since it includes Java, if not 3 which accounts for
+  // the Scala module, the test module, and the Scala 3 module.
+  val desiredSize = if (BuildInfo.millVersion == "0.10.7") 4 else 3
+  assertEquals(semanticdbFiles.size, desiredSize)
   // Then we ensure that the index.scip file was actually created
   assertEquals(os.exists(scipFile), true)
 }

--- a/itest/src/minimal/minimalJava/src/ScipOutputFormat.java
+++ b/itest/src/minimal/minimalJava/src/ScipOutputFormat.java
@@ -1,0 +1,32 @@
+package minimalJava;
+
+/**
+ * Whether to generate index.scip (JSON) or index.scip-protobuf (Protobuf).
+ *
+ * <p>The Protobuf format is experimental and currently only exists as a proof-of-concept.
+ *
+ * NOTE: Taken from https://github.com/sourcegraph/scip-java/blob/main/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipOutputFormat.java
+ */
+public enum ScipOutputFormat {
+  GRAPH_NDJSON,
+  GRAPH_PROTOBUF,
+  TYPED_PROTOBUF,
+  TYPED_NDJSON,
+  UNKNOWN;
+
+  public boolean isTyped() {
+    return this == TYPED_NDJSON || this == TYPED_PROTOBUF;
+  }
+
+  public boolean isNewlineDelimitedJSON() {
+    return this == GRAPH_NDJSON || this == TYPED_NDJSON;
+  }
+
+  public static ScipOutputFormat fromFilename(String name) {
+    if (name.endsWith(".lsif")) return GRAPH_NDJSON;
+    if (name.endsWith(".lsif-protobuf")) return GRAPH_PROTOBUF;
+    if (name.endsWith(".scip")) return TYPED_PROTOBUF;
+    if (name.endsWith(".scip.ndjson")) return TYPED_NDJSON;
+    return UNKNOWN;
+  }
+}

--- a/plugin/src/io/kipp/mill/scip/MillUtils.scala
+++ b/plugin/src/io/kipp/mill/scip/MillUtils.scala
@@ -1,0 +1,15 @@
+package io.kipp.mill.scip
+
+import scala.util.Try
+
+object MillUtils {
+  private[scip] def canHandleJava(millVersion: String) = {
+    Try(millVersion.split('.') match {
+      case Array(major, minor, patch)
+          if (major.toInt > 0 || (minor.toInt >= 10 && patch.toInt >= 6)) =>
+        true
+      case _ => false
+    }).getOrElse(false)
+  }
+
+}

--- a/plugin/src/io/kipp/mill/scip/Scip.scala
+++ b/plugin/src/io/kipp/mill/scip/Scip.scala
@@ -197,7 +197,7 @@ object Scip extends ExternalModule {
           else Seq.empty
 
         val updatedJavacOptions = javacOptions ++ Seq(
-          s"-Xplugin:semanticdb -sourceroot:${T.workspace} -targetroot:${T.dest}"
+          s"-Xplugin:semanticdb -sourceroot:${T.workspace} -targetroot:${T.dest} -build-tool:sbt"
         ) ++ extracJavacExports
 
         log.info(

--- a/plugin/src/io/kipp/mill/scip/Scip.scala
+++ b/plugin/src/io/kipp/mill/scip/Scip.scala
@@ -17,6 +17,7 @@ import mill.scalalib.api.ZincWorkerUtil.isScala3
 import os.Path
 
 import scala.jdk.CollectionConverters._
+import scala.util.Properties
 
 object Scip extends ExternalModule {
 
@@ -140,72 +141,93 @@ object Scip extends ExternalModule {
           reporter = T.reporter.apply(hashCode)
         )
 
-      case jm: JavaModule => {
-        // TODO Right now there seems to be no way to use this on JDK 17. So
-        // dig into the issue below before enabling Java support.
-        // https://github.com/com-lihaoyi/mill/issues/1983
-
-        val name =
+      case jm: JavaModule if MillUtils.canHandleJava(BuildInfo.millVersion) => {
+        val (
+          name,
+          zincWorker,
+          upstreamCompileOutput,
+          sources,
+          compileClasspath,
+          javacOptions
+        ) =
           Evaluator.evalOrThrow(ev) {
             T.task {
               val name = jm.artifactName()
-              // val zincWorker = jm.zincWorker.worker()
-              // val upstreamCompileOutput = jm.upstreamCompileOutput()
-              // val sources = jm.allSourceFiles().map(_.path)
-              // val compileClasspath = jm.compileClasspath().map(_.path)
-              // val javacOptions = jm.javacOptions()
-              name
+              val zincWorker = jm.zincWorker.worker()
+              val upstreamCompileOutput = jm.upstreamCompileOutput()
+              val sources = jm.allSourceFiles().map(_.path)
+              val compileClasspath = jm.compileClasspath().map(_.path)
+              val javacOptions = jm.javacOptions()
+              (
+                name,
+                zincWorker,
+                upstreamCompileOutput,
+                sources,
+                compileClasspath,
+                javacOptions
+              )
             }
           }
 
-        // val updatedCompileClasspath =
-        //  compileClasspath ++ SemanticdbFetcher.getSemanticdbPaths(ev, jm)
+        val semanticDBJavaVersion = ScipBuildInfo.semanticDBJavaVersion
 
-        // lazy val javacModuleOptions =
-        //  List(
-        //    "-J--add-exports",
-        //    "-Jjdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-        //    "-J--add-exports",
-        //    "-Jjdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-        //    "-J--add-exports",
-        //    "-Jjdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-        //    "-J--add-exports",
-        //    "-Jjdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-        //    "-J--add-exports",
-        //    "-Jjdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-        //  )
-
-        // val extracJavacExports =
-        //  if (Properties.isJavaAtLeast(17)) javacModuleOptions.mkString(",")
-        //  else ""
-
-        //// TODO can I also add -build-tool:mill like they do for sbt? What does this do?
-        // val updatedJavacOptions = javacOptions ++ Seq(
-        //  s"-Xplugin:semanticdb -sourceroot:${T.workspace} -targetroot:${T.dest}",
-        //  extracJavacExports
-        // )
-
-        // zincWorker
-        //  .compileJava(
-        //    upstreamCompileOutput,
-        //    sources,
-        //    updatedCompileClasspath,
-        //    updatedJavacOptions,
-        //    T.reporter.apply(hashCode)
-        //  )
         log.info(
-          s"Skipping Java module [${name}] for now, You can track the progress of this in https://github.com/com-lihaoyi/mill/issues/1983"
+          s"Ensuring everything needed for java semanticdb version [${semanticDBJavaVersion}] is available"
+        )
+
+        val updatedCompileClasspath =
+          compileClasspath ++ SemanticdbFetcher.getSemanticdbPaths(ev, jm)
+
+        lazy val javacModuleOptions =
+          List(
+            "-J--add-exports",
+            "-Jjdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+            "-J--add-exports",
+            "-Jjdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            "-J--add-exports",
+            "-Jjdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+            "-J--add-exports",
+            "-Jjdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            "-J--add-exports",
+            "-Jjdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+          )
+
+        val extracJavacExports =
+          if (Properties.isJavaAtLeast(17)) javacModuleOptions
+          else Seq.empty
+
+        val updatedJavacOptions = javacOptions ++ Seq(
+          s"-Xplugin:semanticdb -sourceroot:${T.workspace} -targetroot:${T.dest}"
+        ) ++ extracJavacExports
+
+        log.info(
+          s"Generating semanticdb for [${name}]"
+        )
+
+        zincWorker
+          .compileJava(
+            upstreamCompileOutput,
+            sources,
+            updatedCompileClasspath,
+            updatedJavacOptions,
+            T.reporter.apply(hashCode)
+          )
+      }
+      case jm: JavaModule => {
+        val name = Evaluator.evalOrThrow(ev)(T.task(jm.artifactName()))
+        log.error(
+          s"Skipping ${name}. You must be using at least Mill 0.10.6 to process Java Modules."
         )
       }
     }
 
-    val projects: Seq[Path] = modules
+    val classpath: Seq[Path] = modules
       .flatMap { module =>
         Evaluator.evalOrThrow(ev)(T.task(module.resolvedIvyDeps()))
       }
       .map(_.path)
 
-    createScip(log, T.dest, T.workspace, projects, output, outputFormat)
+    createScip(log, T.dest, T.workspace, classpath, output, outputFormat)
     T.dest / output
   }
 
@@ -243,7 +265,7 @@ object Scip extends ExternalModule {
     *   The destination dir that we'll stick the index in
     * @param workspace
     *   The current workspace root
-    * @param projects
+    * @param classpath
     *   Full classpath of the project to be used for cross-project navigation.
     * @param output
     *   The name out of the output file
@@ -254,7 +276,7 @@ object Scip extends ExternalModule {
       log: Logger,
       dest: Path,
       workspace: Path,
-      projects: Seq[Path],
+      classpath: Seq[Path],
       output: String,
       outputFormat: ScipOutputFormat
   ): Unit = {
@@ -281,12 +303,12 @@ object Scip extends ExternalModule {
     // ScipSemanticdbOptions.
     os.write(
       dest / "javacopts.txt",
-      Seq("-classpath\n", projects.mkString(":")),
+      Seq("-classpath\n", classpath.mkString(":")),
       createFolders = true
     )
 
     val classPathEntries =
-      projects.flatMap(project => ClasspathEntry.fromPom(project.toNIO))
+      classpath.flatMap(project => ClasspathEntry.fromPom(project.toNIO))
 
     log.info(s"Including ${classPathEntries.size} classpath entries")
 

--- a/plugin/test/src/MillUtilsSpec.scala
+++ b/plugin/test/src/MillUtilsSpec.scala
@@ -1,0 +1,21 @@
+package io.kipp.mill.scip
+
+import munit.FunSuite
+
+class MillUtilsSpec extends FunSuite {
+
+  val versions = Map(
+    "nonsense" -> false,
+    "0.9.3-SNAPSHOT" -> false,
+    "0.9.7" -> false,
+    "0.10.5" -> false,
+    "0.10.6" -> true,
+    "0.11.8" -> true,
+    "1.3.8" -> true
+  )
+
+  for ((version, expected) <- versions)
+    test(version) {
+      assertEquals(MillUtils.canHandleJava(version), expected)
+    }
+}


### PR DESCRIPTION
Now that https://github.com/com-lihaoyi/mill/pull/1988 is in a stable
release we can start supporting pure javaModules when the user is on
Java 17 on Mill >= 0.10.6.
