### PR TITLE
chore: update tool name to Mill

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -24,10 +24,10 @@ val scala213 = "2.13.10"
 val semanticdb = "4.5.13"
 val semanticdbJava = "0.8.9"
 
-// We temporarily test against 0.10.7 as well before we have a 0.11.x just
-// to ensure that on that version we can also get semanticDB produced for
-// Java Modules.
-val millTestVersions = Seq(millVersion, "0.10.7")
+// We temporarily test against a newer than 0.10.7 version as well before
+// we have a 0.11.x just to ensure that on that version we can also get
+// semanticDB produced for Java Modules.
+val millTestVersions = Seq(millVersion, "0.10.10")
 
 def millBinaryVersion(millVersion: String) = scalaNativeBinaryVersion(
   millVersion

--- a/plugin/src/io/kipp/mill/scip/Scip.scala
+++ b/plugin/src/io/kipp/mill/scip/Scip.scala
@@ -197,7 +197,7 @@ object Scip extends ExternalModule {
           else Seq.empty
 
         val updatedJavacOptions = javacOptions ++ Seq(
-          s"-Xplugin:semanticdb -sourceroot:${T.workspace} -targetroot:${T.dest} -build-tool:sbt"
+          s"-Xplugin:semanticdb -sourceroot:${T.workspace} -targetroot:${T.dest} -build-tool:mill"
         ) ++ extracJavacExports
 
         log.info(


### PR DESCRIPTION
In the past this was sbt only due to scip-java not accounting for Mill.
After the changes made in
https://github.com/sourcegraph/scip-java/pull/497/files#diff-0e7ae96d79f653d2c89b1b6e6798bffa6b4effd046f340e96ed562a3b15bde4c
we can now just use `mill` as it will correctly set `UriScheme.ZINC`
like we want.
